### PR TITLE
Generate filter description for logging

### DIFF
--- a/controllers/logging/event_controller.go
+++ b/controllers/logging/event_controller.go
@@ -87,7 +87,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	newFilter := newFilter(cr.Spec)
 	if r.Config.filter == nil || !r.Config.filter.Equals(newFilter) {
 		r.Config.filter = newFilter
-		reqLogger.WithValues("filter", r.Config.filter).Info("apply new filter")
+		reqLogger.WithValues("filter", r.Config.filter.String()).Info("apply new filter")
 		needUpdate = true
 	}
 

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -1,6 +1,8 @@
 package filter
 
 import (
+	"strings"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -12,16 +14,19 @@ type Filter interface {
 	Match(*corev1.Event) bool
 	// Equals compares the Filter with another
 	Equals(Filter) bool
+	// String returns the description of the Filter
+	String() string
 }
 
 // New creates a new Filter from a filter function: func(*corev1.Event) bool
-func New(f func(*corev1.Event) bool) Filter {
-	return &Func{Func: f}
+func New(f func(*corev1.Event) bool, description string) Filter {
+	return &Func{Func: f, Description: description}
 }
 
 // Func is a generic Filter
 type Func struct {
-	Func func(*corev1.Event) bool
+	Func        func(*corev1.Event) bool
+	Description string
 }
 
 // Match implements Filter interface
@@ -34,11 +39,16 @@ func (f *Func) Equals(o Filter) bool {
 	return cmp.Equal(f, o, cmpopts.EquateEmpty())
 }
 
+func (f *Func) String() string {
+	return f.Description
+}
+
 // Never is a filter that never matches
 var Never = &Func{
 	Func: func(_ *corev1.Event) bool {
 		return false
 	},
+	Description: "false",
 }
 
 // Always is a filter that always matches
@@ -46,6 +56,7 @@ var Always = &Func{
 	Func: func(_ *corev1.Event) bool {
 		return true
 	},
+	Description: "true",
 }
 
 // Slice is a slice of Filter
@@ -54,7 +65,7 @@ type Slice []Filter
 // Any creates a new Filter which checks if least one Filter in the Slice matches (if the Slice is empty this is equivalent to Never)
 func (s Slice) Any() Filter {
 	return &Func{
-		func(e *corev1.Event) bool {
+		Func: func(e *corev1.Event) bool {
 			for _, filter := range s {
 				if filter.Match(e) {
 					return true
@@ -62,13 +73,14 @@ func (s Slice) Any() Filter {
 			}
 			return false
 		},
+		Description: "( " + strings.Join(s.toStringSlice(), " OR ") + " )",
 	}
 }
 
 // All creates a new Filter which checks if all Filter in the Slice matches (if the Slice is empty this is equivalent to Always)
 func (s Slice) All() Filter {
 	return &Func{
-		func(e *corev1.Event) bool {
+		Func: func(e *corev1.Event) bool {
 			for _, filter := range s {
 				if !filter.Match(e) {
 					return false
@@ -76,5 +88,17 @@ func (s Slice) All() Filter {
 			}
 			return true
 		},
+		Description: "( " + strings.Join(s.toStringSlice(), " AND ") + " )",
 	}
+}
+
+// toStringSlice creates a slice with the descriptions of all the Filter in Slice
+func (s Slice) toStringSlice() []string {
+	var descriptions []string
+
+	for _, filter := range s {
+		descriptions = append(descriptions, filter.String())
+	}
+
+	return descriptions
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -10,20 +10,24 @@ import (
 func Test_Filter_Match_Always(t *testing.T) {
 	Assert(t, Always.Match(&corev1.Event{}) == true)
 	Assert(t, Always.Match(nil) == true)
+	Assert(t, Always.String() == "true")
 }
 
 func Test_Filter_Match_Never(t *testing.T) {
 	Assert(t, Never.Match(&corev1.Event{}) == false)
 	Assert(t, Never.Match(nil) == false)
+	Assert(t, Never.String() == "false")
 }
 
 func Test_Filter_Match_Func(t *testing.T) {
+	description := "type =='Bar'"
 	filter := New(func(event *corev1.Event) bool {
 		return event.Type == "Bar"
-	})
+	}, description)
 
 	Assert(t, filter.Match(&corev1.Event{Type: "Foo"}) == false)
 	Assert(t, filter.Match(&corev1.Event{Type: "Bar"}) == true)
+	Assert(t, filter.String() == description)
 }
 
 func Test_Slice_Match_All(t *testing.T) {
@@ -31,6 +35,7 @@ func Test_Slice_Match_All(t *testing.T) {
 	Assert(t, Slice{Always}.All().Match(&corev1.Event{}) == true)
 	Assert(t, Slice{}.All().Match(&corev1.Event{}) == true)
 	Assert(t, Slice{Never, Always}.All().Match(&corev1.Event{}) == false)
+	Assert(t, Slice{Never, Always, Never}.All().String() == "( false AND true AND false )")
 }
 
 func Test_Slice_Match_Any(t *testing.T) {
@@ -39,4 +44,11 @@ func Test_Slice_Match_Any(t *testing.T) {
 	Assert(t, Slice{}.Any().Match(&corev1.Event{}) == false)
 	Assert(t, Slice{Never}.Any().Match(&corev1.Event{}) == false)
 	Assert(t, Slice{Never, Never}.Any().Match(&corev1.Event{}) == false)
+	Assert(t, Slice{Never, Always, Never}.Any().String() == "( false OR true OR false )")
+}
+
+func Test_Nested_Slice_Match(t *testing.T) {
+	filter := Slice{Slice{Never, Always}.Any(), Slice{Always, Always}.All()}.All()
+	Assert(t, filter.Match(&corev1.Event{}) == true)
+	Assert(t, filter.String() == "( ( false OR true ) AND ( true AND true ) )")
 }


### PR DESCRIPTION
The logging of the new filter introduced in #81 fails:
```
{"level":"info","ts":1614694965.9681294,"logger":"controllers.Event","msg":"apply new filter","namespace":"sdx-argocd-apps","name":"argocd-auditlog","filterError":"json: unsupported type: func(*v1.Event) bool"}
```

This PR introduces a new way to retrieve the descriptions of a filter:
```
( ( ( Kind == 'Pod' AND EventType in [Warning] ) ) )
( EventType in [Warning] OR ( ( Kind == 'Pod' AND EventType in [Normal] ) ) )
( ( ( Kind == 'Pod' AND ( false XOR ( Message matches /.*message.*/ ) ) ) ) )
```