### PR TITLE
fix: remove spaces in map keys

### DIFF
--- a/controllers/logging/event_controller.go
+++ b/controllers/logging/event_controller.go
@@ -163,8 +163,8 @@ func (p *loggingPredicate) logEvent(e runtime.Object) bool {
 				"reason", evt.Reason,
 				"timestamp", evt.LastTimestamp,
 				"type", evt.Type,
-				"involvedObject ", evt.InvolvedObject,
-				"source ", evt.Source,
+				"involvedObject", evt.InvolvedObject,
+				"source", evt.Source,
 			)
 		} else {
 			m := structs.Map(evt)


### PR DESCRIPTION
Removes extraneous trailing spaces in map keys which are causing problems in other tools working with these logs.